### PR TITLE
[fix] DiscordAPIError for long taf

### DIFF
--- a/src/app/commands/weather/taf.js
+++ b/src/app/commands/weather/taf.js
@@ -34,16 +34,53 @@ module.exports = class TafCommand extends Command {
     try {
       const { raw, readable } = await Avwx.getTaf(icao);
 
-      tafEmbed.addFields(
-        {
-          name: 'Raw Report',
-          value: raw
-        },
-        {
-          name: 'Readable Report',
-          value: readable
+      if (readable.length < 600) {
+        tafEmbed.addField('Raw Report', raw);
+        tafEmbed.addField('Readable Report', readable);
+        return msg.embed(tafEmbed);
+      } else {
+        const tafEmbeds = [];
+        let tempEmbed = new Discord.MessageEmbed()
+          .setTitle(`TAF for ${icao.toUpperCase()}`)
+          .setColor('#0099ff')
+          .addField('Raw Report', raw)
+          .setFooter(this.client.user.username)
+          .setTimestamp();
+
+        tafEmbeds.push(tempEmbed);
+
+        const readableList = readable.split('. ');
+        let buffer = "";
+
+        for (let i = 0; i < readableList.length; i += 1) {
+          const currentLine = `${readableList[i]}. `;
+          buffer += currentLine;
+          if (buffer.length > 600) {
+            tempEmbed = new Discord.MessageEmbed()
+              .setTitle(`TAF for ${icao.toUpperCase()}`)
+              .setColor('#0099ff')
+              .addField(`Readable Report [${tafEmbeds.length}]`, buffer)
+              .setFooter(this.client.user.username)
+              .setTimestamp();
+
+            tafEmbeds.push(tempEmbed);
+            buffer = "";
+          }
         }
-      );
+
+        tempEmbed = tafEmbed;
+        tafEmbeds.push(tempEmbed.addField(`Readable Report [${tafEmbeds.length}]`, buffer));
+        // console.log(tafEmbeds);
+
+
+
+        for (let i = 0; i < tafEmbeds.length; i +=1 ) {
+          // eslint-disable-next-line no-await-in-loop
+          await msg.embed(tafEmbeds[i].setFooter(`${this.client.user.username} • Message ${i + 1} of ${tafEmbeds.length}`));
+        }
+
+        return null;
+      }
     } catch (error) {
       logger.error(`[${this.client.shard.ids}] ${error}`);
       try {

--- a/src/app/commands/weather/taf.js
+++ b/src/app/commands/weather/taf.js
@@ -50,7 +50,7 @@ module.exports = class TafCommand extends Command {
         tafEmbeds.push(tempEmbed);
 
         const readableList = readable.split('. ');
-        let buffer = "";
+        let buffer = '';
 
         for (let i = 0; i < readableList.length; i += 1) {
           const currentLine = `${readableList[i]}. `;
@@ -64,7 +64,7 @@ module.exports = class TafCommand extends Command {
               .setTimestamp();
 
             tafEmbeds.push(tempEmbed);
-            buffer = "";
+            buffer = '';
           }
         }
 
@@ -72,9 +72,7 @@ module.exports = class TafCommand extends Command {
         tafEmbeds.push(tempEmbed.addField(`Readable Report [${tafEmbeds.length}]`, buffer));
         // console.log(tafEmbeds);
 
-
-
-        for (let i = 0; i < tafEmbeds.length; i +=1 ) {
+        for (let i = 0; i < tafEmbeds.length; i += 1) {
           // eslint-disable-next-line no-await-in-loop
           await msg.embed(tafEmbeds[i].setFooter(`${this.client.user.username} • Message ${i + 1} of ${tafEmbeds.length}`));
         }


### PR DESCRIPTION
# Description

Fixes `An error occurred while running the command: DiscordAPIError: Invalid Form Body embed.fields[1].value: Must be 1024 or fewer in length.` which were caused because of long TAF messages.

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested with short TAF which were already working.
- [x] Tested with long TAF which were breaking.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation/readme
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
