### PR TITLE
[fix] regex matching special chars

### DIFF
--- a/src/app/commands/ivao/ivao-online.js
+++ b/src/app/commands/ivao/ivao-online.js
@@ -17,7 +17,7 @@ module.exports = class IvaoOnlineCommand extends Command {
           key: 'partialCallSign',
           prompt: 'What partial callsign would you like the bot to give information for?',
           type: 'string',
-          parse: (val) => val.toUpperCase()
+          parse: (val) => val.toUpperCase().replace(/[^A-Z0-9_]/g, '')
         }
       ]
     });

--- a/src/app/commands/vatsim/vatsim-online.js
+++ b/src/app/commands/vatsim/vatsim-online.js
@@ -17,7 +17,7 @@ module.exports = class VatsimOnlineCommand extends Command {
           key: 'partialCallSign',
           prompt: 'What partial call sign would you like the bot to give information for?',
           type: 'string',
-          parse: (val) => val.toUpperCase()
+          parse: (val) => val.toUpperCase().replace(/[^A-Z0-9_]/g, '')
         }
       ]
     });
@@ -36,7 +36,7 @@ module.exports = class VatsimOnlineCommand extends Command {
       vatsimEmbed.setTitle(`VATSIM : ${partialCallSign}`);
 
       atcList.forEach((atc) => {
-        vatsimEmbed.addField(`${atc.callSign}`, `VID: ${atc.vid}, Frequency: ${atc.frequency}`);
+        vatsimEmbed.addField(`${atc.callSign}`, `CID: ${atc.cid}, Frequency: ${atc.frequency}`);
       });
     } catch (error) {
       logger.error(`[${this.client.shard.ids}] ${error}`);


### PR DESCRIPTION
# Description

If the request callsign contained a special character which regex uses, it will perform a regex operation but it is not intended.
The fix is to strip/replace all these special characters in the starting of the function

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] with normal callsign argument
- [x] with special characters in callsign argument

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation/readme
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
