### PR TITLE
Handle missing frequency description

### DIFF
--- a/src/commands/Station.ts
+++ b/src/commands/Station.ts
@@ -135,7 +135,12 @@ export class IcaoStation {
     }
 
     private getFrequenciesStr(frequencies: AirportFrequency[]): string {
-        return frequencies.map((freq) => `${freq.description}: ${Number(freq.frequency_mhz).toFixed(3).toString()}`).join("\n");
+        return frequencies
+            .map((freq) => {
+                const description = freq.type + freq.description ? ` (${freq.description})` : "";
+                return `${description}: ${Number(freq.frequency_mhz).toFixed(3).toString()}`;
+            })
+            .join("\n");
     }
 
     private getLinks(station: Station): string {


### PR DESCRIPTION
frequency description is missing sometimes, so fallback and concat the freq type and description to create an overall description